### PR TITLE
chore: init go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/tmknom/bump
+
+go 1.17


### PR DESCRIPTION
runned the following command:

```
go mod init github.com/tmknom/bump
```
